### PR TITLE
typos on tutorial and binder issues (#560)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In this repository, we've put together a collection of Jupyter notebooks aimed a
 
 The notebooks for these tutorials can be viewed here on GitHub. But for the full experience, you'll want to interact with them!
 
-The easiest way to do this is using [the Binder image](https://mybinder.org/v2/gh/Qiskit/qiskit-tutorial/master?filepath=index.ipynb), which lets you use the notebooks via the web. This means that you don't need to download or install anything, but it also means that you should not insert any private information into the notebooks (such as your API key). We recommend as pointed out in [issue #231](https://github.com/Qiskit/qiskit-tutorial/issues/231) that after you are done using mybinder that you regenerate your token.
+The easiest way to do this is using [the Binder image](https://mybinder.org/v2/gh/qiskit/qiskit-tutorials/master?filepath=index.ipynb), which lets you use the notebooks via the web. This means that you don't need to download or install anything, but it also means that you should not insert any private information into the notebooks (such as your API key). We recommend as pointed out in [issue #231](https://github.com/Qiskit/qiskit-tutorial/issues/231) that after you are done using mybinder that you regenerate your token.
 
 Please refer to this [installation guide](INSTALL.md) for setting up Qiskit and the tutorials on your own machine (this is the recommended way).
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: Qiskitenv
 dependencies:
-- python=3
+- python==3.6
 - pip=18
 - matplotlib
 - notebook

--- a/qiskit/basics/getting_started_with_qiskit.ipynb
+++ b/qiskit/basics/getting_started_with_qiskit.ipynb
@@ -205,7 +205,7 @@
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
     "\n",
-    "When representing the state of a multi-qubit system, the tensor order used in qiskit is different than that use in most physics textbooks. Suppose there are $n$ qubits, and qubit $j$ is labeled as $Q_{j}$. In most textbooks (such as Nielsen and Chuang's \"Quantum Computation and Information\"), the basis vectors for the $n$-qubit state space would be labeled as $Q_{0}\\otimes Q_{1} \\otimes \\cdots \\otimes Q_{n}$. **This is not the ordering used by qiskit!** Instead, qiskit uses an ordering in which the $n^{\\mathrm{th}}$ qubit is on the _left_ side of the tesnsor product, so that the basis vectors are labeled as  $Q_n\\otimes \\cdots  \\otimes  Q_1\\otimes Q_0$.\n",
+    "When representing the state of a multi-qubit system, the tensor order used in qiskit is different than that use in most physics textbooks. Suppose there are $n$ qubits, and qubit $j$ is labeled as $Q_{j}$. In most textbooks (such as Nielsen and Chuang's \"Quantum Computation and Information\"), the basis vectors for the $n$-qubit state space would be labeled as $Q_{0}\\otimes Q_{1} \\otimes \\cdots \\otimes Q_{n}$. **This is not the ordering used by qiskit!** Instead, qiskit uses an ordering in which the $n^{\\mathrm{th}}$ qubit is on the <em><strong>left</strong></em> side of the tensor product, so that the basis vectors are labeled as  $Q_n\\otimes \\cdots  \\otimes  Q_1\\otimes Q_0$.\n",
     "\n",
     "For example, if qubit zero is in state 0, qubit 1 is in state 0, and qubit 2 is in state 1, qiskit would represent this state as $|100\\rangle$, whereas most physics textbooks would represent it as $|001\\rangle$.\n",
     "\n",
@@ -588,7 +588,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After generating your API token, call, `IBMQ.save_account('MY_TOKEN')`. For Q Network users, you'll also need to include your access url: `IBMQ.save_account('MY_TOKEN', 'URL')`\n",
+    "After generating your API token, call: `IBMQ.save_account('MY_TOKEN')`. For Q Network users, you'll also need to include your access url: `IBMQ.save_account('MY_TOKEN', 'URL')`\n",
     "\n",
     "This will store your IBMQ credentials in a local file.  Unless your registration information has changed, you only need to do this once.  You may now load your accounts by calling,"
    ]


### PR DESCRIPTION
* slides typo corrections

teach_me_quantum_2018/TeachMeQ/Week_0-Hello_Quantum_World/slides.pdf 
slides 9 and 12

* typo correction

small typos on the qiskit/basics/getting_started_with_qiskit.ipynb

* bold and italic correction

bold and italic now correctly applied.

* punctuation

comma to collon

* Update README.md

trying to fix the binder notebooks

* binder fixes

trying to fix the binder notebooks

* fixing binder

i think i could fix the binder issues. simply by using lowercase on the username "qiskit" and correcting the the path to (...)tutorials instead of (...)tutorial forced it to rebuild the binder image.
:)
if this alone is not enough then we may try to specify python==3.6, because one guy here (https://gitter.im/jupyterhub/binder) was able to make it work just by doing so.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


